### PR TITLE
Add artifact uploads to CI build job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,3 +119,17 @@ jobs:
           else
             flutter build appbundle --release
           fi
+
+      - name: Upload Linux artifacts
+        if: matrix.target == 'linux'
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-release-bundle
+          path: build/linux/x64/release/bundle/
+
+      - name: Upload Android artifacts
+        if: matrix.target == 'android'
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-release-appbundle
+          path: build/app/outputs/bundle/release/app-release.aab


### PR DESCRIPTION
### **User description**
## Summary
- add upload-artifact steps to publish linux and android build outputs from CI

## Testing
- not run (workflow change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6949b782753c8328ad9333400e6d9389)


___

### **PR Type**
Enhancement


___

### **Description**
- Add artifact upload steps to CI workflow

- Upload Linux release bundle from build output

- Upload Android release app bundle from build output

- Enable downloading build artifacts from CI runs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Release Binaries"] --> B["Upload Linux Artifacts"]
  A --> C["Upload Android Artifacts"]
  B --> D["Downloadable Artifacts"]
  C --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yaml</strong><dd><code>Add artifact uploads for Linux and Android builds</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/ci.yaml

<ul><li>Add upload-artifact step for Linux release bundle targeting <br><code>build/linux/x64/release/bundle/</code><br> <li> Add upload-artifact step for Android release app bundle targeting <br><code>build/app/outputs/bundle/release/app-release.aab</code><br> <li> Conditionally execute uploads based on target platform using <br>matrix.target<br> <li> Enable CI workflow to publish build outputs as downloadable artifacts</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/36/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133dd">+14/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

