### PR TITLE
Guard dialog flows with `mounted` and remove unused override

### DIFF
--- a/lib/features/home/pages/theta_home_dialogs.dart
+++ b/lib/features/home/pages/theta_home_dialogs.dart
@@ -2,7 +2,6 @@ part of 'theta_home_page.dart';
 
 mixin _DialogBuilders on State<ThetaHomePage> {
   // Members provided by _ThetaHomePageState
-  AudioPlayer get _dialogAudioPlayer;
   Future<void> _stopDialogAudioAndRestoreMusic();
   Future<void> _playDialogAudioWithMusicFade(String assetPath);
   Future<void> _duckMusicForIntro();
@@ -221,6 +220,7 @@ mixin _DialogBuilders on State<ThetaHomePage> {
   // ignore: unused_element
   Future<void> _showAboutDialog() async {
     await _playDialogAudioWithMusicFade('audio/what_is_theta.mp3');
+    if (!mounted) return;
 
     final ScrollController scrollController = ScrollController();
 
@@ -599,6 +599,7 @@ mixin _DialogBuilders on State<ThetaHomePage> {
   // ignore: unused_element
   Future<void> _showGuideMeInfo() async {
     await _playDialogAudioWithMusicFade('audio/guide_me_info.mp3');
+    if (!mounted) return;
 
     final ScrollController scrollController = ScrollController();
 
@@ -827,6 +828,7 @@ mixin _DialogBuilders on State<ThetaHomePage> {
   /// FIX #8 & #11: Guide Me Response Dialog with Option 5 styling and 30000ms auto-scroll
   Future<void> _showResponseDialog(String response) async {
     await _duckMusicForIntro();
+    if (!mounted) return;
     final ScrollController scrollController = ScrollController();
 
     await showDialog(

--- a/lib/features/home/pages/theta_home_page.dart
+++ b/lib/features/home/pages/theta_home_page.dart
@@ -34,7 +34,6 @@ class _ThetaHomePageState extends State<ThetaHomePage>
   final ThetaAudioService _audioService = ThetaAudioService();
 
   // SEPARATE audio player for dialog TTS (What is Theta, Guide Me info)
-  @override
   final AudioPlayer _dialogAudioPlayer = AudioPlayer();
   StreamSubscription<void>? _dialogCompleteSubscription;
 


### PR DESCRIPTION
### **User description**
### Motivation
- Ensure dialog presentation does not use `BuildContext` after async gaps to satisfy the `use_build_context_synchronously` lint.
- Remove an incorrect/unused override and getter for the dialog audio player to clear analyzer warnings.

### Description
- Add `if (!mounted) return;` after awaiting dialog audio calls in `_showAboutDialog`, `_showGuideMeInfo`, and `_showResponseDialog`.
- Remove the `AudioPlayer get _dialogAudioPlayer;` declaration from the `_DialogBuilders` mixin.
- Remove the `@override` annotation from the `_dialogAudioPlayer` field in `_ThetaHomePageState`.

### Testing
- Ran `flutter pub get` and dependency resolution completed successfully.
- Ran `flutter analyze` and it reported `No issues found`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6964c54ee20083289f00a110074b058f)


___

### **PR Type**
Bug fix


___

### **Description**
- Add mounted guards after async dialog audio calls

- Remove unused AudioPlayer getter from mixin declaration

- Remove incorrect @override annotation from dialog audio player field


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dialog Methods<br/>showAboutDialog<br/>showGuideMeInfo<br/>showResponseDialog"] -->|"Add mounted check<br/>after await"| B["Prevent BuildContext<br/>usage after async gap"]
  C["_DialogBuilders Mixin"] -->|"Remove getter<br/>declaration"| D["Eliminate unused<br/>abstract member"]
  E["_ThetaHomePageState"] -->|"Remove @override<br/>annotation"| F["Fix incorrect<br/>override marker"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>theta_home_dialogs.dart</strong><dd><code>Add mounted guards to dialog methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/features/home/pages/theta_home_dialogs.dart

<ul><li>Add <code>if (!mounted) return;</code> guard after <code>await </code><br><code>_playDialogAudioWithMusicFade()</code> in <code>_showAboutDialog()</code><br> <li> Add <code>if (!mounted) return;</code> guard after <code>await </code><br><code>_playDialogAudioWithMusicFade()</code> in <code>_showGuideMeInfo()</code><br> <li> Add <code>if (!mounted) return;</code> guard after <code>await _duckMusicForIntro()</code> in <br><code>_showResponseDialog()</code><br> <li> Remove unused <code>AudioPlayer get _dialogAudioPlayer;</code> getter declaration <br>from <code>_DialogBuilders</code> mixin</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/52/files#diff-48db8399194276f30bce58fbc0cd5c74e44fdb81c9bcef87dd4a1027e93f6b86">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>theta_home_page.dart</strong><dd><code>Remove incorrect override annotation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/features/home/pages/theta_home_page.dart

<ul><li>Remove <code>@override</code> annotation from <code>_dialogAudioPlayer</code> field in <br><code>_ThetaHomePageState</code> class<br> <li> Field declaration remains unchanged, only annotation removed</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/52/files#diff-4690322a3dc4ff9710bb44f8489a0866fc0afe1af4efa4e633128a55ce234009">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

