### PR TITLE
Fix macOS xcconfig include and align pubspec dependency bounds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ generate_what_is_theta.py
 .dart_tool
 .flutter-plugins-dependencies
 .flutter-plugins
-macos/Flutter
+macos/Flutter/ephemeral/

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -34,6 +34,7 @@ end
 
 post_install do |installer|
   installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
     end

--- a/macos/Flutter/Flutter-Debug.xcconfig
+++ b/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"

--- a/macos/Flutter/Flutter-Release.xcconfig
+++ b/macos/Flutter/Flutter-Release.xcconfig
@@ -1,0 +1,1 @@
+#include "ephemeral/Flutter-Generated.xcconfig"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,22 +11,22 @@ dependencies:
     sdk: flutter
   
   # Audio playback engine
-  audioplayers: ^6.1.0
+  audioplayers: ^6.5.1
   
   # Background audio service
-  audio_service: ^0.18.12
+  audio_service: ^0.18.18
   
   # Video playback
-  video_player: ^2.8.1
+  video_player: ^2.10.1
     
   # HTTP requests (for Guide Me API)
-  http: ^1.1.0
+  http: ^1.6.0
   
   # Google Fonts (Option 5 "Soft & Spiritual" styling)
-  google_fonts: ^6.1.0
+  google_fonts: ^6.3.3
   
   # Native splash screen (FIX: Prevents icon showing on white screen at startup)
-  flutter_native_splash: ^2.3.8
+  flutter_native_splash: ^2.4.7
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### **User description**
### Motivation
- Resolve macOS build errors caused by missing Flutter xcconfig includes by restoring the expected include chain under `macos/Flutter`.
- Reduce dependency constraint mismatches by aligning `pubspec.yaml` bounds with the resolved versions in `pubspec.lock` so `flutter pub` commands will not report incompatible constraints.

### Description
- Add `macos/Flutter/Flutter-Debug.xcconfig` and `macos/Flutter/Flutter-Release.xcconfig` that `#include "ephemeral/Flutter-Generated.xcconfig"` to restore the macOS xcconfig include chain.
- Update `.gitignore` to ignore only `macos/Flutter/ephemeral/` instead of the whole `macos/Flutter` directory so generated ephemeral files remain excluded while allowing the added xcconfig stubs.
- Bump direct dependency constraints in `pubspec.yaml` for `audioplayers`, `audio_service`, `video_player`, `http`, `google_fonts`, and `flutter_native_splash` to the versions resolved in `pubspec.lock`.
- Commit message: `Fix macOS Flutter xcconfig setup`.

### Testing
- Queried `pub.dev` for latest package versions with a Python script to confirm current resolved versions (succeeded).
- Inspected `pubspec.lock` to verify the versions used and updated `pubspec.yaml` accordingly (succeeded).
- Attempted `flutter pub outdated` and `flutter analyze` but `flutter` was not available in this environment, so those checks could not be run (failed due to missing tool).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696768e0f7b0832aad0b93705f294b34)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Restore macOS xcconfig include chain with Flutter-Debug and Flutter-Release stubs

- Update pubspec.yaml dependency bounds to match resolved versions

- Align audioplayers, audio_service, video_player, http, google_fonts, flutter_native_splash versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["macOS Build Issue"] -->|"Add xcconfig stubs"| B["Flutter-Debug/Release.xcconfig"]
  B -->|"Include ephemeral"| C["Flutter-Generated.xcconfig"]
  D["Dependency Mismatch"] -->|"Update bounds"| E["pubspec.yaml"]
  E -->|"Align with lock"| F["Resolved Versions"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Flutter-Debug.xcconfig</strong><dd><code>Add Flutter Debug xcconfig include stub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

macos/Flutter/Flutter-Debug.xcconfig

<ul><li>New file created to restore xcconfig include chain<br> <li> Includes ephemeral/Flutter-Generated.xcconfig for macOS build <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/55/files#diff-d6092dfe1ec34d44b3639907e52f9ef886b03e8324a158c915422a0a0420f3bc">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Flutter-Release.xcconfig</strong><dd><code>Add Flutter Release xcconfig include stub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

macos/Flutter/Flutter-Release.xcconfig

<ul><li>New file created to restore xcconfig include chain<br> <li> Includes ephemeral/Flutter-Generated.xcconfig for macOS build <br>configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/55/files#diff-b412b53b35cb1d383f2fed7735e93b80147214f423a6f431c4841b05461b2390">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pubspec.yaml</strong><dd><code>Update dependency version constraints to match lock</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pubspec.yaml

<ul><li>Bump audioplayers from ^6.1.0 to ^6.5.1<br> <li> Bump audio_service from ^0.18.12 to ^0.18.18<br> <li> Bump video_player from ^2.8.1 to ^2.10.1<br> <li> Bump http from ^1.1.0 to ^1.6.0<br> <li> Bump google_fonts from ^6.1.0 to ^6.3.3<br> <li> Bump flutter_native_splash from ^2.3.8 to ^2.4.7</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/55/files#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

