### PR TITLE
Windows chrome fixes and intro playback improvements (border, remove hover buttons, video sizing & splash)

### DIFF
--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -22,6 +22,7 @@
 // - Smooth fade transitions
 
 import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 import 'package:theta_audio_mvp/app/router.dart';
@@ -64,6 +65,8 @@ class _IntroScreenState extends State<IntroScreen> {
   bool _showFadeOverlay = false;
   bool _showLatestPc = false;
   double _latestPcOpacity = 0.0;
+  final bool _allowPlaybackFallbacks =
+      defaultTargetPlatform != TargetPlatform.windows;
 
   @override
   void initState() {
@@ -71,7 +74,7 @@ class _IntroScreenState extends State<IntroScreen> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         precacheImage(
-          const AssetImage('assets/images/LATEST PC.png'),
+          const AssetImage('assets/images/latest_pc.png'),
           context,
         );
         _initializeIntroVideo();
@@ -117,11 +120,13 @@ class _IntroScreenState extends State<IntroScreen> {
       // Wait for first frame to actually render (surface-ready detection)
       await _waitForFirstFrame(_introVideoController!, 'intro');
 
-      // Start timeout timer (fallback if video hangs)
-      _startIntroTimeout();
+      if (_allowPlaybackFallbacks) {
+        // Start timeout timer (fallback if video hangs)
+        _startIntroTimeout();
 
-      // Start playback monitor to detect stuck video
-      _startPlaybackMonitor();
+        // Start playback monitor to detect stuck video
+        _startPlaybackMonitor();
+      }
 
       // Pre-load instruction video while intro plays
       _preloadInstructionVideo();
@@ -153,8 +158,10 @@ class _IntroScreenState extends State<IntroScreen> {
       await _introVideoController!.play();
 
       await _waitForFirstFrame(_introVideoController!, 'intro');
-      _startIntroTimeout();
-      _startPlaybackMonitor();
+      if (_allowPlaybackFallbacks) {
+        _startIntroTimeout();
+        _startPlaybackMonitor();
+      }
       _preloadInstructionVideo();
     } catch (e) {
       debugPrint('❌ Fallback also failed: $e');
@@ -405,7 +412,9 @@ class _IntroScreenState extends State<IntroScreen> {
     await _waitForFirstFrame(_instructionVideoController!, 'instruction');
 
     // Start timeout timer
-    _startInstructionTimeout();
+    if (_allowPlaybackFallbacks) {
+      _startInstructionTimeout();
+    }
   }
 
   // Start timeout timer for instruction video
@@ -470,40 +479,17 @@ class _IntroScreenState extends State<IntroScreen> {
     _introVideoController?.pause();
     _instructionVideoController?.pause();
 
-    // Show fade overlay
-    setState(() {
-      _showFadeOverlay = true;
-    });
-
-    // Animate fade to white (800ms)
-    for (int i = 0; i <= 16; i++) {
-      await Future.delayed(const Duration(milliseconds: 50));
-      if (mounted) {
-        setState(() {
-          _fadeOverlay = i / 16.0;
-        });
-      }
-    }
-
-    debugPrint('✅ Fade to white complete');
-
-    // Fade in LATEST PC splash on white overlay
+    // Show white overlay and LATEST PC splash immediately
     if (mounted) {
       setState(() {
+        _showFadeOverlay = true;
+        _fadeOverlay = 1.0;
         _showLatestPc = true;
+        _latestPcOpacity = 1.0;
       });
 
-      for (int i = 0; i <= 16; i++) {
-        await Future.delayed(const Duration(milliseconds: 50));
-        if (mounted) {
-          setState(() {
-            _latestPcOpacity = i / 16.0;
-          });
-        }
-      }
-
       // Briefly hold the splash before navigating
-      await Future.delayed(const Duration(milliseconds: 800));
+      await Future.delayed(const Duration(milliseconds: 1200));
     }
 
     // Navigate to main app with fade transition (4000ms)
@@ -567,10 +553,11 @@ class _IntroScreenState extends State<IntroScreen> {
                 child: Container(
                   color: Colors.white,
                   child: Center(
-                    child: Image.asset(
-                      'assets/images/LATEST PC.png',
-                      width: 320,
-                      fit: BoxFit.contain,
+                    child: SizedBox.expand(
+                      child: Image.asset(
+                        'assets/images/latest_pc.png',
+                        fit: BoxFit.contain,
+                      ),
                     ),
                   ),
                 ),
@@ -584,40 +571,14 @@ class _IntroScreenState extends State<IntroScreen> {
   Widget _buildVideoContent() {
     // Show intro video
     if (_showingIntro && _isIntroInitialized && _introVideoController != null) {
-      final size = _introVideoController!.value.size;
-      return ColoredBox(
-        color: Colors.black,
-        child: Center(
-          child: FittedBox(
-            fit: BoxFit.contain, // ✅ FIX: no crop/zoom
-            child: SizedBox(
-              width: size.width,
-              height: size.height,
-              child: VideoPlayer(_introVideoController!),
-            ),
-          ),
-        ),
-      );
+      return _buildVideoPlayer(_introVideoController!);
     }
 
     // Show instruction video
     if (_showingInstruction &&
         _isInstructionInitialized &&
         _instructionVideoController != null) {
-      final size = _instructionVideoController!.value.size;
-      return ColoredBox(
-        color: Colors.black,
-        child: Center(
-          child: FittedBox(
-            fit: BoxFit.contain, // ✅ FIX: no crop/zoom
-            child: SizedBox(
-              width: size.width,
-              height: size.height,
-              child: VideoPlayer(_instructionVideoController!),
-            ),
-          ),
-        ),
-      );
+      return _buildVideoPlayer(_instructionVideoController!);
     }
 
     // Show subtle loading spinner
@@ -628,6 +589,21 @@ class _IntroScreenState extends State<IntroScreen> {
         child: CircularProgressIndicator(
           strokeWidth: 2,
           valueColor: AlwaysStoppedAnimation<Color>(Colors.white24),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildVideoPlayer(VideoPlayerController controller) {
+    final aspectRatio = controller.value.aspectRatio;
+    final safeAspectRatio = aspectRatio > 0 ? aspectRatio : 16 / 9;
+
+    return ColoredBox(
+      color: Colors.black,
+      child: Center(
+        child: AspectRatio(
+          aspectRatio: safeAspectRatio,
+          child: VideoPlayer(controller),
         ),
       ),
     );

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -2,8 +2,6 @@
 
 #include <dwmapi.h>
 #include <flutter_windows.h>
-#include <windowsx.h>
-
 #include "resource.h"
 
 namespace {
@@ -15,6 +13,9 @@ namespace {
 /// See: https://docs.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#ifndef DWMWA_BORDER_COLOR
+#define DWMWA_BORDER_COLOR 34
 #endif
 
 constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
@@ -206,7 +207,6 @@ Win32Window::MessageHandler(HWND hwnd,
         MoveWindow(child_content_, rect.left, rect.top, rect.right - rect.left,
                    rect.bottom - rect.top, TRUE);
       }
-      UpdateCaptionButtonsLayout();
       return 0;
     }
 
@@ -220,39 +220,6 @@ Win32Window::MessageHandler(HWND hwnd,
       UpdateTheme(hwnd);
       return 0;
 
-    case WM_MOUSEMOVE: {
-      EnsureMouseTracking();
-      POINT pt{GET_X_LPARAM(lparam), GET_Y_LPARAM(lparam)};
-      ToggleCaptionButtonsVisibility(IsPointInButtonRegion(pt));
-      break;
-    }
-
-    case WM_MOUSELEAVE:
-      tracking_mouse_leave_ = false;
-      ToggleCaptionButtonsVisibility(false);
-      break;
-
-    case WM_COMMAND:
-      if (HIWORD(wparam) == BN_CLICKED) {
-        HWND source = reinterpret_cast<HWND>(lparam);
-        if (source == minimize_button_) {
-          ShowWindow(window_handle_, SW_MINIMIZE);
-          return 0;
-        }
-        if (source == maximize_button_) {
-          if (IsZoomed(window_handle_)) {
-            ShowWindow(window_handle_, SW_RESTORE);
-          } else {
-            ShowWindow(window_handle_, SW_MAXIMIZE);
-          }
-          return 0;
-        }
-        if (source == close_button_) {
-          PostMessage(window_handle_, WM_CLOSE, 0, 0);
-          return 0;
-        }
-      }
-      break;
   }
 
   return DefWindowProc(window_handle_, message, wparam, lparam);
@@ -330,7 +297,8 @@ void Win32Window::InitializeCustomChrome() {
   }
 
   LONG style = GetWindowLong(window_handle_, GWL_STYLE);
-  style &= ~(WS_CAPTION | WS_THICKFRAME | WS_BORDER);
+  style &= ~(WS_CAPTION | WS_THICKFRAME);
+  style |= WS_BORDER;
   SetWindowLong(window_handle_, GWL_STYLE, style);
   LONG ex_style = GetWindowLong(window_handle_, GWL_EXSTYLE);
   ex_style &= ~WS_EX_CLIENTEDGE;
@@ -339,110 +307,8 @@ void Win32Window::InitializeCustomChrome() {
                SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER |
                    SWP_NOACTIVATE);
 
-  CreateCaptionButtons();
-  UpdateCaptionButtonsLayout();
-  ToggleCaptionButtonsVisibility(false);
-}
+  const COLORREF border_color = RGB(0, 0, 0);
+  DwmSetWindowAttribute(window_handle_, DWMWA_BORDER_COLOR, &border_color,
+                        sizeof(border_color));
 
-void Win32Window::CreateCaptionButtons() {
-  if (!window_handle_) {
-    return;
-  }
-
-  UINT dpi = GetDpiForWindow(window_handle_);
-  double scale_factor = dpi / 96.0;
-  int buttonWidth = Scale(32, scale_factor);
-  int buttonHeight = Scale(24, scale_factor);
-
-  minimize_button_ = CreateWindowEx(
-      0, L"BUTTON", L"–", WS_CHILD, 0, 0, buttonWidth, buttonHeight,
-      window_handle_, reinterpret_cast<HMENU>(1), GetModuleHandle(nullptr),
-      nullptr);
-
-  maximize_button_ = CreateWindowEx(
-      0, L"BUTTON", L"□", WS_CHILD, 0, 0, buttonWidth, buttonHeight,
-      window_handle_, reinterpret_cast<HMENU>(2), GetModuleHandle(nullptr),
-      nullptr);
-
-  close_button_ = CreateWindowEx(0, L"BUTTON", L"✕", WS_CHILD, 0, 0,
-                                 buttonWidth, buttonHeight, window_handle_,
-                                 reinterpret_cast<HMENU>(3),
-                                 GetModuleHandle(nullptr), nullptr);
-}
-
-void Win32Window::UpdateCaptionButtonsLayout() {
-  if (!window_handle_ || !minimize_button_ || !maximize_button_ ||
-      !close_button_) {
-    return;
-  }
-
-  RECT rect = GetClientArea();
-  UINT dpi = GetDpiForWindow(window_handle_);
-  double scale_factor = dpi / 96.0;
-  int buttonWidth = Scale(32, scale_factor);
-  int buttonHeight = Scale(24, scale_factor);
-  int padding = Scale(8, scale_factor);
-  int spacing = Scale(6, scale_factor);
-
-  int x = rect.right - padding - buttonWidth;
-  int y = padding;
-
-  SetWindowPos(close_button_, HWND_TOP, x, y, buttonWidth, buttonHeight,
-               SWP_NOACTIVATE);
-  x -= buttonWidth + spacing;
-  SetWindowPos(maximize_button_, HWND_TOP, x, y, buttonWidth, buttonHeight,
-               SWP_NOACTIVATE);
-  x -= buttonWidth + spacing;
-  SetWindowPos(minimize_button_, HWND_TOP, x, y, buttonWidth, buttonHeight,
-               SWP_NOACTIVATE);
-}
-
-void Win32Window::ToggleCaptionButtonsVisibility(bool show) {
-  if (!minimize_button_ || !maximize_button_ || !close_button_) {
-    return;
-  }
-
-  if (buttons_visible_ == show) {
-    return;
-  }
-
-  int command = show ? SW_SHOWNOACTIVATE : SW_HIDE;
-  ShowWindow(minimize_button_, command);
-  ShowWindow(maximize_button_, command);
-  ShowWindow(close_button_, command);
-  buttons_visible_ = show;
-}
-
-bool Win32Window::IsPointInButtonRegion(POINT pt) const {
-  if (!window_handle_) {
-    return false;
-  }
-
-  RECT rect;
-  GetClientRect(window_handle_, &rect);
-  UINT dpi = GetDpiForWindow(window_handle_);
-  double scale_factor = dpi / 96.0;
-
-  int buttonWidth = Scale(32, scale_factor);
-  int padding = Scale(8, scale_factor);
-  int spacing = Scale(6, scale_factor);
-  int regionWidth = padding * 2 + (buttonWidth * 3) + (spacing * 2);
-  int regionHeight = Scale(48, scale_factor);
-
-  RECT hoverRegion = {rect.right - regionWidth, 0, rect.right, regionHeight};
-  return PtInRect(&hoverRegion, pt);
-}
-
-void Win32Window::EnsureMouseTracking() {
-  if (tracking_mouse_leave_ || !window_handle_) {
-    return;
-  }
-
-  TRACKMOUSEEVENT tme{};
-  tme.cbSize = sizeof(TRACKMOUSEEVENT);
-  tme.dwFlags = TME_LEAVE;
-  tme.hwndTrack = window_handle_;
-  if (TrackMouseEvent(&tme)) {
-    tracking_mouse_leave_ = true;
-  }
 }

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -91,11 +91,6 @@ class Win32Window {
   static void UpdateTheme(HWND const window);
 
   void InitializeCustomChrome();
-  void CreateCaptionButtons();
-  void UpdateCaptionButtonsLayout();
-  void ToggleCaptionButtonsVisibility(bool show);
-  bool IsPointInButtonRegion(POINT pt) const;
-  void EnsureMouseTracking();
 
   bool quit_on_close_ = false;
 
@@ -105,12 +100,6 @@ class Win32Window {
   // window handle for hosted content.
   HWND child_content_ = nullptr;
 
-  // Custom caption buttons (hover only)
-  HWND minimize_button_ = nullptr;
-  HWND maximize_button_ = nullptr;
-  HWND close_button_ = nullptr;
-  bool tracking_mouse_leave_ = false;
-  bool buttons_visible_ = false;
 };
 
 #endif  // RUNNER_WIN32_WINDOW_H_


### PR DESCRIPTION
### **User description**
### Motivation
- Restore a thin, consistent black rim on Windows while removing fragile hover-only caption controls so the app chrome is visually rimless and simpler to maintain.
- Ensure the intro/instruction videos reliably display on Windows even when the player reports a zero size by providing a safe aspect-ratio fallback and surface-ready checks.
- Make the post‑video splash deterministic and visible by using the correct `latest_pc.png` asset and expanding it to fill the white overlay.

### Description
- Added a `DWMWA_BORDER_COLOR` fallback macro and call to `DwmSetWindowAttribute` with `RGB(0,0,0)` and kept `WS_BORDER` in `windows/runner/win32_window.cpp` to ensure a thin black window rim is drawn.
- Removed all hover-only caption button creation, layout, mouse-tracking, and command-handling code from `windows/runner/win32_window.cpp` and removed their declarations from `windows/runner/win32_window.h` to simplify non-client handling.
- In `lib/intro_screen.dart` implemented a reusable `_buildVideoPlayer` that uses `controller.value.aspectRatio` with a `16/9` fallback to avoid zero-size video surfaces, and expanded the `latest_pc.png` splash to `SizedBox.expand` so it always fills the white overlay.
- Added `_allowPlaybackFallbacks = defaultTargetPlatform != TargetPlatform.windows` and guarded timeout/monitor startup so Windows skips automatic fallback/forced-skip logic, and made the fade/navigation show the white overlay and splash at full opacity and hold for `1200ms` before navigating.

### Testing
- Attempted `flutter analyze`, but it failed because `flutter` is not installed in the environment so static analysis could not be completed (error: `flutter: command not found`).
- No other automated tests were available in this environment; manual runtime verification on Windows is recommended to confirm taskbar visibility, video playback, and splash display.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696e4994b674832aa79dbea76ce8e9c2)


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Improved intro/instruction video sizing with aspect-ratio fallback for Windows

- Disabled automatic playback fallbacks and monitoring on Windows platform

- Simplified Windows chrome by removing hover-only caption buttons

- Enhanced splash screen display with immediate full opacity and extended hold time

- Fixed asset filename casing from 'LATEST PC.png' to 'latest_pc.png'


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Video Player"] -->|"AspectRatio fallback 16/9"| B["Safe Video Sizing"]
  C["Windows Platform"] -->|"Skip fallbacks"| D["Disable Timeouts & Monitoring"]
  E["Splash Screen"] -->|"Immediate opacity + 1200ms hold"| F["Enhanced Display"]
  G["Caption Buttons"] -->|"Remove hover logic"| H["Simplified Chrome"]
  I["Border Color"] -->|"DwmSetWindowAttribute RGB0,0,0"| J["Thin Black Rim"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>intro_screen.dart</strong><dd><code>Video sizing fallback and splash screen improvements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/intro_screen.dart

<ul><li>Added <code>_allowPlaybackFallbacks</code> flag to skip timeout/monitor logic on <br>Windows<br> <li> Implemented reusable <code>_buildVideoPlayer()</code> method with AspectRatio <br>widget and 16/9 fallback for zero-size videos<br> <li> Refactored video player UI to use new <code>_buildVideoPlayer()</code> for both <br>intro and instruction videos<br> <li> Changed splash screen to show white overlay and image at full opacity <br>immediately instead of animating<br> <li> Extended splash hold duration from 800ms to 1200ms before navigation<br> <li> Fixed asset filename from 'LATEST PC.png' to 'latest_pc.png' <br>(lowercase)<br> <li> Added import for <code>package:flutter/foundation.dart</code> to access <br><code>defaultTargetPlatform</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/57/files#diff-47b66c316fddd42b1c6510d9d45dbe590b899b70f17957d8ba0f9357fa01736e">+44/-68</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>win32_window.cpp</strong><dd><code>Remove caption buttons and add black border</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/runner/win32_window.cpp

<ul><li>Removed <code>#include <windowsx.h></code> dependency<br> <li> Added <code>DWMWA_BORDER_COLOR</code> macro definition for older Windows SDK <br>compatibility<br> <li> Removed all hover-only caption button creation, layout, visibility <br>toggle, and mouse tracking logic<br> <li> Removed <code>WM_SIZE</code>, <code>WM_MOUSEMOVE</code>, <code>WM_MOUSELEAVE</code>, and <code>WM_COMMAND</code> message <br>handlers related to caption buttons<br> <li> Modified <code>InitializeCustomChrome()</code> to keep <code>WS_BORDER</code> style and set <br>black border color via <code>DwmSetWindowAttribute()</code><br> <li> Simplified window styling by removing caption button creation and <br>layout calls</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/57/files#diff-ec8ddea5fb936073514e9b70cd0172fd200aab5e82a8ddca545f6586978b6611">+8/-142</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>win32_window.h</strong><dd><code>Remove caption button related declarations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

windows/runner/win32_window.h

<ul><li>Removed method declarations for <code>CreateCaptionButtons()</code>, <br><code>UpdateCaptionButtonsLayout()</code>, <code>ToggleCaptionButtonsVisibility()</code>, <br><code>IsPointInButtonRegion()</code>, and <code>EnsureMouseTracking()</code><br> <li> Removed member variables for caption button handles (<code>minimize_button_</code>, <br><code>maximize_button_</code>, <code>close_button_</code>)<br> <li> Removed mouse tracking state variable <code>tracking_mouse_leave_</code> and button <br>visibility flag <code>buttons_visible_</code></ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/57/files#diff-def70167b3ce830477c450d831266578c0111f148af03ab7b818cc7f59f33246">+0/-11</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

