### PR TITLE
Consolidate periodic refresh handling

### DIFF
--- a/lib/divine_shuffle_popup.dart
+++ b/lib/divine_shuffle_popup.dart
@@ -87,7 +87,6 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
 
   // Track previous session for time-based changes
   String _currentSessionType = '';
-  Timer? _sessionCheckTimer;
 
   // Auto-scroll for highlighted prayer card (green/blue box)
   final ScrollController _prayerCardScrollController = ScrollController();
@@ -146,7 +145,6 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   @override
   void dispose() {
     _shuffleTimer?.cancel();
-    _sessionCheckTimer?.cancel();
     _introScrollTimer?.cancel();
     _prayerCardAutoScrollTimer?.cancel();
     _ttsCompletionSubscription?.cancel();
@@ -328,19 +326,21 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
     });
 
     widget.onPhase1Complete?.call();
-
-    // Start session check timer (check every 60 seconds for time-based changes)
-    _sessionCheckTimer = Timer.periodic(const Duration(seconds: 60), (_) {
-      _checkSessionChange();
-    });
   }
 
   // ═══════════════════════════════════════════════════════════════════════════
   // SESSION CHANGE DETECTION (Time-based transitions)
   // ═══════════════════════════════════════════════════════════════════════════
 
+  void refreshSessionIfNeeded() {
+    if (!mounted || _currentIntroPart != 0) return;
+    _checkSessionChange();
+  }
+
   void _checkSessionChange() {
-    if (widget.isGoliathMode) return; // Don't check time when in Goliath mode
+    if (!mounted || widget.isGoliathMode) {
+      return; // Don't check time when in Goliath mode or after disposal
+    }
 
     final newSessionType = _getSessionType();
     if (newSessionType != _currentSessionType) {
@@ -351,10 +351,12 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   }
 
   Future<void> _handleSessionChange(String newSession) async {
+    if (!mounted) return;
     // Fade out top panel
     setState(() => _topPanelOpacity = 0.0);
     await Future.delayed(const Duration(milliseconds: 500));
 
+    if (!mounted) return;
     // Update prayer list and session
     _currentSessionType = newSession;
     _initializePrayerList();

--- a/lib/divine_shuffle_popup.dart
+++ b/lib/divine_shuffle_popup.dart
@@ -25,6 +25,8 @@ import 'prayers_list.dart';
 import 'goliath_prayers_list.dart';
 import 'prayer_texts.dart';
 
+final ValueNotifier<int> refreshNotifier = ValueNotifier<int>(0);
+
 class DivineShufflePopup extends StatefulWidget {
   final bool isVisible;
   final bool isGoliathMode;
@@ -91,6 +93,7 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   // Auto-scroll for highlighted prayer card (green/blue box)
   final ScrollController _prayerCardScrollController = ScrollController();
   Timer? _prayerCardAutoScrollTimer;
+  late final VoidCallback _refreshListener;
 
   // ═══════════════════════════════════════════════════════════════════════════
   // COLORS - Option 5 "Soft & Spiritual" Theme (EXACT MATCH)
@@ -115,6 +118,11 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
     super.initState();
     _initializePrayerList();
     _currentSessionType = _getSessionType();
+    _refreshListener = () {
+      if (!mounted || _currentIntroPart != 0) return;
+      _checkSessionChange();
+    };
+    refreshNotifier.addListener(_refreshListener);
 
     if (widget.isVisible) {
       _startIntroSequence();
@@ -153,6 +161,7 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
     _part3ScrollController.dispose();
     _prayerCardScrollController.dispose();
     _ttsPlayer?.dispose();
+    refreshNotifier.removeListener(_refreshListener);
     super.dispose();
   }
 
@@ -331,11 +340,6 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   // ═══════════════════════════════════════════════════════════════════════════
   // SESSION CHANGE DETECTION (Time-based transitions)
   // ═══════════════════════════════════════════════════════════════════════════
-
-  void refreshSessionIfNeeded() {
-    if (!mounted || _currentIntroPart != 0) return;
-    _checkSessionChange();
-  }
 
   void _checkSessionChange() {
     if (!mounted || widget.isGoliathMode) {

--- a/lib/features/home/pages/theta_home_page.dart
+++ b/lib/features/home/pages/theta_home_page.dart
@@ -130,9 +130,7 @@ class _ThetaHomePageState extends State<ThetaHomePage>
 
       // Start status auto-refresh timer (every 1 minute)
       _statusRefreshTimer = Timer.periodic(const Duration(minutes: 1), (timer) {
-        if (mounted && _isActive && !_isGoliathMode) {
-          setState(() {}); // Triggers UI rebuild to update time status
-        }
+        _handlePeriodicRefresh();
       });
 
       setState(() {
@@ -143,6 +141,9 @@ class _ThetaHomePageState extends State<ThetaHomePage>
 
       // Start wallpaper fade-in over 4 seconds (opacity 0→1)
       _startWallpaperFadeIn();
+
+      // Refresh status immediately instead of waiting for the first timer tick.
+      _handlePeriodicRefresh();
 
       // Divine Shuffle appears at 7 seconds (3 seconds after wallpaper fade-in completes at 4s)
       Future.delayed(const Duration(seconds: 7), () {
@@ -163,6 +164,14 @@ class _ThetaHomePageState extends State<ThetaHomePage>
         _isInitialized = false;
       });
     }
+  }
+
+  void _handlePeriodicRefresh() {
+    if (!mounted) return;
+    if (_isActive && !_isGoliathMode) {
+      setState(() {}); // Triggers UI rebuild to update time status
+    }
+    _divineShuffleKey.currentState?.refreshSessionIfNeeded();
   }
 
   /// NEW: Called when prayer changes (Divine Shuffle sync)

--- a/lib/features/home/pages/theta_home_page.dart
+++ b/lib/features/home/pages/theta_home_page.dart
@@ -92,10 +92,22 @@ class _ThetaHomePageState extends State<ThetaHomePage>
   // Goliath Mode
   @override
   bool _isGoliathMode = false;
+  String _lastSessionType = '';
+  late final VoidCallback _refreshListener;
 
   @override
   void initState() {
     super.initState();
+    _refreshListener = () {
+      if (!mounted || !_isActive || _isGoliathMode) return;
+      final newSessionType = _getSessionType();
+      if (_lastSessionType != newSessionType) {
+        setState(() {
+          _lastSessionType = newSessionType;
+        });
+      }
+    };
+    refreshNotifier.addListener(_refreshListener);
     _initializeApp();
   }
 
@@ -168,10 +180,14 @@ class _ThetaHomePageState extends State<ThetaHomePage>
 
   void _handlePeriodicRefresh() {
     if (!mounted) return;
-    if (_isActive && !_isGoliathMode) {
-      setState(() {}); // Triggers UI rebuild to update time status
-    }
-    _divineShuffleKey.currentState?.refreshSessionIfNeeded();
+    refreshNotifier.value++;
+  }
+
+  String _getSessionType() {
+    final hour = DateTime.now().hour;
+    if (hour >= 5 && hour < 11) return 'morning';
+    if (hour >= 11 && hour < 18) return 'midday';
+    return 'evening';
   }
 
   /// NEW: Called when prayer changes (Divine Shuffle sync)
@@ -825,6 +841,7 @@ class _ThetaHomePageState extends State<ThetaHomePage>
     _dialogAudioPlayer.dispose();
     _musicPlayer?.dispose();
     _guideMeController.dispose();
+    refreshNotifier.removeListener(_refreshListener);
     super.dispose();
   }
 

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -22,9 +22,7 @@
 // - Smooth fade transitions
 
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:video_player/video_player.dart';
 import 'package:theta_audio_mvp/app/router.dart';
 
@@ -75,8 +73,6 @@ class _IntroScreenState extends State<IntroScreen> {
   bool _isIntroInitializing = false;
   bool _isInstructionInitializing = false;
   static const Duration _videoInitTimeout = Duration(seconds: 30);
-  File? _introTempFile;
-  File? _instructionTempFile;
 
   @override
   void initState() {
@@ -151,43 +147,10 @@ class _IntroScreenState extends State<IntroScreen> {
     } catch (e, stack) {
       debugPrint('❌ ERROR LOADING INTRO VIDEO: $e');
       debugPrint('Stack: $stack');
-      await _tryFileIntroFallback('assets/video/intro_video.mp4');
+      // Try MOV format as fallback
+      _tryFallbackIntroFormat();
     } finally {
       _isIntroInitializing = false;
-    }
-  }
-
-  Future<void> _tryFileIntroFallback(String assetPath) async {
-    try {
-      debugPrint('🔄 Trying intro fallback via file load');
-      _introVideoController?.removeListener(_checkIntroProgress);
-      _introVideoController?.dispose();
-      _introPlaybackStarted = false;
-      _introTempFile = await _loadAssetToFile(assetPath, 'intro_video.mp4');
-      _introVideoController = VideoPlayerController.file(_introTempFile!);
-
-      await _initializeController(_introVideoController!, 'intro file');
-      await _introVideoController!.setVolume(1.0);
-
-      setState(() {
-        _isIntroInitialized = true;
-      });
-
-      _introVideoController!.addListener(_checkIntroProgress);
-      await _introVideoController!.play();
-      _introPlaybackStarted = true;
-
-      await _ensurePlaybackStarted(_introVideoController!, 'intro');
-      await _waitForFirstFrame(_introVideoController!, 'intro');
-      if (_allowPlaybackFallbacks) {
-        _startIntroTimeout();
-        _startPlaybackMonitor();
-      }
-      _preloadInstructionVideo();
-    } catch (fallbackError, fallbackStack) {
-      debugPrint('❌ File fallback failed: $fallbackError');
-      debugPrint('Stack: $fallbackStack');
-      _tryFallbackIntroFormat();
     }
   }
 
@@ -484,39 +447,9 @@ class _IntroScreenState extends State<IntroScreen> {
     } catch (e, stack) {
       debugPrint('❌ ERROR LOADING INSTRUCTION VIDEO: $e');
       debugPrint('Stack: $stack');
-      await _tryInstructionFileFallback('assets/video/instruction_vid.mp4');
+      await _retryInstructionInitialization();
     } finally {
       _isInstructionInitializing = false;
-    }
-  }
-
-  Future<void> _tryInstructionFileFallback(String assetPath) async {
-    try {
-      debugPrint('🔄 Trying instruction fallback via file load');
-      _instructionVideoController?.removeListener(_checkInstructionProgress);
-      _instructionVideoController?.dispose();
-      _instructionPlaybackStarted = false;
-      _instructionTempFile =
-          await _loadAssetToFile(assetPath, 'instruction_vid.mp4');
-      _instructionVideoController = VideoPlayerController.file(
-        _instructionTempFile!,
-      );
-
-      await _initializeController(
-        _instructionVideoController!,
-        'instruction file',
-      );
-      await _instructionVideoController!.setVolume(1.0);
-
-      setState(() {
-        _isInstructionInitialized = true;
-      });
-
-      _startInstructionVideo();
-    } catch (fallbackError, fallbackStack) {
-      debugPrint('❌ Instruction file fallback failed: $fallbackError');
-      debugPrint('Stack: $fallbackStack');
-      await _retryInstructionInitialization();
     }
   }
 
@@ -600,16 +533,6 @@ class _IntroScreenState extends State<IntroScreen> {
     } on TimeoutException {
       throw TimeoutException('Video init timed out: $label');
     }
-  }
-
-  Future<File> _loadAssetToFile(String assetPath, String fileName) async {
-    final data = await rootBundle.load(assetPath);
-    final bytes = data.buffer.asUint8List();
-    final directory = Directory.systemTemp;
-    final filePath = '${directory.path}${Platform.pathSeparator}$fileName';
-    final file = File(filePath);
-    await file.writeAsBytes(bytes, flush: true);
-    return file;
   }
 
   Future<void> _retryIntroInitialization() async {
@@ -710,8 +633,6 @@ class _IntroScreenState extends State<IntroScreen> {
     // Dispose controllers
     _introVideoController?.dispose();
     _instructionVideoController?.dispose();
-    _deleteTempFile(_introTempFile);
-    _deleteTempFile(_instructionTempFile);
 
     debugPrint('✅ Intro screen disposed');
     super.dispose();
@@ -805,14 +726,4 @@ class _IntroScreenState extends State<IntroScreen> {
     );
   }
 
-  void _deleteTempFile(File? file) {
-    if (file == null) return;
-    try {
-      if (file.existsSync()) {
-        file.deleteSync();
-      }
-    } catch (_) {
-      // Ignore cleanup errors.
-    }
-  }
 }

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -72,7 +72,7 @@ class _IntroScreenState extends State<IntroScreen> {
   static const int _maxInitRetries = 2;
   bool _isIntroInitializing = false;
   bool _isInstructionInitializing = false;
-  static const Duration _videoInitTimeout = Duration(seconds: 8);
+  static const Duration _videoInitTimeout = Duration(seconds: 30);
 
   @override
   void initState() {

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -217,31 +217,19 @@ class _IntroScreenState extends State<IntroScreen> {
         return;
       }
 
-      // Also check if video has frames ready
-      if (controller.value.isInitialized &&
-          controller.value.size.width > 0 &&
-          controller.value.size.height > 0 &&
-          isPlaying) {
-        debugPrint('✅ Video surface ready ($videoName)');
-        return;
-      }
-
-      if (attempts % 10 == 0) {
-        debugPrint(
-            '   Still waiting... attempt $attempts, isPlaying: $isPlaying, position: ${position.inMilliseconds}ms');
+      // Also check if video has frames ready (buffering indicator)
+      if (controller.value.isBuffering) {
+        debugPrint('⏳ Video buffering ($videoName)...');
       }
     }
 
-    debugPrint('⚠️ First frame wait timeout ($videoName) - proceeding anyway');
+    debugPrint(
+        '⚠️ Timeout waiting for first frame ($videoName) after 5 seconds');
   }
 
   Future<void> _ensurePlaybackStarted(
       VideoPlayerController controller, String videoName) async {
-    if (!controller.value.isInitialized) {
-      return;
-    }
-
-    for (var attempt = 1; attempt <= 3; attempt++) {
+    for (int attempt = 1; attempt <= 5; attempt++) {
       await Future.delayed(const Duration(milliseconds: 250));
       final value = controller.value;
       if (value.isPlaying ||
@@ -662,25 +650,39 @@ class _IntroScreenState extends State<IntroScreen> {
             ),
 
           // LATEST PC splash on white background
-          if (_showLatestPc)
-            Positioned.fill(
-              child: AnimatedOpacity(
-                opacity: _latestPcOpacity,
-                duration: const Duration(milliseconds: 50),
-                child: Container(
-                  color: Colors.white,
-                  child: Center(
-                    child: SizedBox.expand(
-                      child: Image.asset(
-                        'assets/images/latest_pc.png',
-                        fit: BoxFit.contain,
-                      ),
+        if (_showLatestPc)
+          Positioned.fill(
+            child: AnimatedOpacity(
+              opacity: _latestPcOpacity,
+              duration: const Duration(milliseconds: 50),
+              child: Container(
+                color: Colors.white,
+                child: Center(
+                  child: SizedBox.expand(
+                    child: Image.asset(
+                      'assets/images/latest_pc.png',
+                      fit: BoxFit.contain,
                     ),
                   ),
                 ),
               ),
             ),
-        ],
+          ),
+        if (!_isIntroInitialized && !_hasNavigated) _buildLoadingIndicator(),
+      ],
+    ),
+  );
+}
+
+  Widget _buildLoadingIndicator() {
+    return const Center(
+      child: SizedBox(
+        width: 32,
+        height: 32,
+        child: CircularProgressIndicator(
+          strokeWidth: 2,
+          valueColor: AlwaysStoppedAnimation<Color>(Colors.white24),
+        ),
       ),
     );
   }
@@ -698,17 +700,7 @@ class _IntroScreenState extends State<IntroScreen> {
       return _buildVideoPlayer(_instructionVideoController!);
     }
 
-    // Show subtle loading spinner
-    return const Center(
-      child: SizedBox(
-        width: 32,
-        height: 32,
-        child: CircularProgressIndicator(
-          strokeWidth: 2,
-          valueColor: AlwaysStoppedAnimation<Color>(Colors.white24),
-        ),
-      ),
-    );
+    return const SizedBox.expand();
   }
 
   Widget _buildVideoPlayer(VideoPlayerController controller) {

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -72,6 +72,7 @@ class _IntroScreenState extends State<IntroScreen> {
   static const int _maxInitRetries = 2;
   bool _isIntroInitializing = false;
   bool _isInstructionInitializing = false;
+  static const Duration _videoInitTimeout = Duration(seconds: 8);
 
   @override
   void initState() {
@@ -94,6 +95,7 @@ class _IntroScreenState extends State<IntroScreen> {
     try {
       _introVideoController?.removeListener(_checkIntroProgress);
       _introVideoController?.dispose();
+      _introPlaybackStarted = false;
       debugPrint('═══════════════════════════════════════════════════════');
       debugPrint('🎬 THETA INTRO SCREEN - INITIALIZING VIDEO 1 (INTRO)');
       debugPrint('═══════════════════════════════════════════════════════');
@@ -105,7 +107,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
       debugPrint('📹 Loading $videoPath from assets...');
 
-      await _introVideoController!.initialize();
+      await _initializeController(_introVideoController!, 'intro');
 
       debugPrint('✅ Intro video initialized');
       debugPrint(
@@ -158,10 +160,11 @@ class _IntroScreenState extends State<IntroScreen> {
       debugPrint('🔄 Trying fallback format: intro_video.mov');
 
       _introVideoController?.dispose();
+      _introPlaybackStarted = false;
       _introVideoController =
           VideoPlayerController.asset('assets/video/intro_video.mov');
 
-      await _introVideoController!.initialize();
+      await _initializeController(_introVideoController!, 'intro fallback');
       await _introVideoController!.setVolume(1.0);
 
       setState(() {
@@ -340,7 +343,10 @@ class _IntroScreenState extends State<IntroScreen> {
         'assets/video/instruction_vid.mp4',
       );
 
-      await _instructionVideoController!.initialize();
+      await _initializeController(
+        _instructionVideoController!,
+        'instruction preload',
+      );
       await _instructionVideoController!.setVolume(1.0);
 
       setState(() {
@@ -425,11 +431,12 @@ class _IntroScreenState extends State<IntroScreen> {
 
       _instructionVideoController?.removeListener(_checkInstructionProgress);
       _instructionVideoController?.dispose();
+      _instructionPlaybackStarted = false;
       _instructionVideoController = VideoPlayerController.asset(
         'assets/video/instruction_vid.mp4',
       );
 
-      await _instructionVideoController!.initialize();
+      await _initializeController(_instructionVideoController!, 'instruction');
       await _instructionVideoController!.setVolume(1.0);
 
       setState(() {
@@ -517,6 +524,15 @@ class _IntroScreenState extends State<IntroScreen> {
     debugPrint('✅ $reason');
     _instructionCompleted = true;
     _startFadeAndNavigate();
+  }
+
+  Future<void> _initializeController(
+      VideoPlayerController controller, String label) async {
+    try {
+      await controller.initialize().timeout(_videoInitTimeout);
+    } on TimeoutException {
+      throw TimeoutException('Video init timed out: $label');
+    }
   }
 
   Future<void> _retryIntroInitialization() async {

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -22,6 +22,7 @@
 // - Smooth fade transitions
 
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
 import 'package:theta_audio_mvp/app/router.dart';
@@ -53,6 +54,7 @@ class _IntroScreenState extends State<IntroScreen> {
   Timer? _introTimeoutTimer;
   Timer? _instructionTimeoutTimer;
   Timer? _playbackMonitorTimer;
+  Timer? _windowsFallbackTimer;
 
   // Track last position for stuck detection
   Duration _lastIntroPosition = Duration.zero;
@@ -84,6 +86,21 @@ class _IntroScreenState extends State<IntroScreen> {
           context,
         );
         _initializeIntroVideo();
+        if (Platform.isWindows) {
+          _startWindowsFallbackTimer();
+        }
+      }
+    });
+  }
+
+  void _startWindowsFallbackTimer() {
+    _windowsFallbackTimer?.cancel();
+    _windowsFallbackTimer = Timer(const Duration(seconds: 5), () {
+      if (!mounted || _hasNavigated) return;
+      if (!_introPlaybackStarted && !_instructionPlaybackStarted) {
+        debugPrint(
+            '⚠️ WINDOWS FALLBACK - videos did not start, navigating to home');
+        _startFadeAndNavigate();
       }
     });
   }
@@ -127,6 +144,7 @@ class _IntroScreenState extends State<IntroScreen> {
       // Start playback
       await _introVideoController!.play();
       _introPlaybackStarted = true;
+      _windowsFallbackTimer?.cancel();
       debugPrint('▶️ Intro video play() called...');
 
       await _ensurePlaybackStarted(_introVideoController!, 'intro');
@@ -453,6 +471,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
     await _instructionVideoController!.play();
     _instructionPlaybackStarted = true;
+    _windowsFallbackTimer?.cancel();
     debugPrint('▶️ Instruction video playing...');
 
     await _ensurePlaybackStarted(_instructionVideoController!, 'instruction');
@@ -568,7 +587,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
   // Start fade to white and navigate to main app
   Future<void> _startFadeAndNavigate() async {
-    if (_hasNavigated || !_instructionCompleted) return;
+    if (_hasNavigated) return;
     _hasNavigated = true;
 
     debugPrint('═══════════════════════════════════════════════════════');
@@ -579,6 +598,7 @@ class _IntroScreenState extends State<IntroScreen> {
     _introTimeoutTimer?.cancel();
     _instructionTimeoutTimer?.cancel();
     _playbackMonitorTimer?.cancel();
+    _windowsFallbackTimer?.cancel();
 
     // Stop any playing video
     _introVideoController?.pause();
@@ -613,6 +633,7 @@ class _IntroScreenState extends State<IntroScreen> {
     _introTimeoutTimer?.cancel();
     _instructionTimeoutTimer?.cancel();
     _playbackMonitorTimer?.cancel();
+    _windowsFallbackTimer?.cancel();
 
     // Remove listeners
     _introVideoController?.removeListener(_checkIntroProgress);
@@ -650,29 +671,29 @@ class _IntroScreenState extends State<IntroScreen> {
             ),
 
           // LATEST PC splash on white background
-        if (_showLatestPc)
-          Positioned.fill(
-            child: AnimatedOpacity(
-              opacity: _latestPcOpacity,
-              duration: const Duration(milliseconds: 50),
-              child: Container(
-                color: Colors.white,
-                child: Center(
-                  child: SizedBox.expand(
-                    child: Image.asset(
-                      'assets/images/latest_pc.png',
-                      fit: BoxFit.contain,
+          if (_showLatestPc)
+            Positioned.fill(
+              child: AnimatedOpacity(
+                opacity: _latestPcOpacity,
+                duration: const Duration(milliseconds: 50),
+                child: Container(
+                  color: Colors.white,
+                  child: Center(
+                    child: SizedBox.expand(
+                      child: Image.asset(
+                        'assets/images/latest_pc.png',
+                        fit: BoxFit.contain,
+                      ),
                     ),
                   ),
                 ),
               ),
             ),
-          ),
-        if (!_isIntroInitialized && !_hasNavigated) _buildLoadingIndicator(),
-      ],
-    ),
-  );
-}
+          if (!_isIntroInitialized && !_hasNavigated) _buildLoadingIndicator(),
+        ],
+      ),
+    );
+  }
 
   Widget _buildLoadingIndicator() {
     return const Center(

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -65,6 +65,11 @@ class _IntroScreenState extends State<IntroScreen> {
   bool _showLatestPc = false;
   double _latestPcOpacity = 0.0;
   final bool _allowPlaybackFallbacks = true;
+  bool _introPlaybackStarted = false;
+  bool _instructionPlaybackStarted = false;
+  int _introInitRetryCount = 0;
+  int _instructionInitRetryCount = 0;
+  static const int _maxInitRetries = 2;
 
   @override
   void initState() {
@@ -83,6 +88,8 @@ class _IntroScreenState extends State<IntroScreen> {
   // Initialize intro video (Video 1) with surface-ready detection
   Future<void> _initializeIntroVideo() async {
     try {
+      _introVideoController?.removeListener(_checkIntroProgress);
+      _introVideoController?.dispose();
       debugPrint('═══════════════════════════════════════════════════════');
       debugPrint('🎬 THETA INTRO SCREEN - INITIALIZING VIDEO 1 (INTRO)');
       debugPrint('═══════════════════════════════════════════════════════');
@@ -113,6 +120,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
       // Start playback
       await _introVideoController!.play();
+      _introPlaybackStarted = true;
       debugPrint('▶️ Intro video play() called...');
 
       await _ensurePlaybackStarted(_introVideoController!, 'intro');
@@ -156,6 +164,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
       _introVideoController!.addListener(_checkIntroProgress);
       await _introVideoController!.play();
+      _introPlaybackStarted = true;
 
       await _ensurePlaybackStarted(_introVideoController!, 'intro');
 
@@ -167,8 +176,7 @@ class _IntroScreenState extends State<IntroScreen> {
       _preloadInstructionVideo();
     } catch (e) {
       debugPrint('❌ Fallback also failed: $e');
-      // Skip to instruction video
-      _switchToInstructionVideo();
+      _retryIntroInitialization();
     }
   }
 
@@ -250,7 +258,7 @@ class _IntroScreenState extends State<IntroScreen> {
 
     _introTimeoutTimer?.cancel();
     _introTimeoutTimer = Timer(timeoutDuration, () {
-      if (!_introCompleted && mounted) {
+      if (!_introCompleted && mounted && _introPlaybackStarted) {
         debugPrint('⚠️ INTRO VIDEO TIMEOUT - forcing switch to instruction');
         _switchToInstructionVideo();
       }
@@ -305,7 +313,9 @@ class _IntroScreenState extends State<IntroScreen> {
 
           if (_stuckFrameCount >= 6) {
             debugPrint('🔄 Video stuck for 3 seconds - forcing navigation');
-            _startFadeAndNavigate();
+            if (_instructionPlaybackStarted) {
+              _markInstructionComplete('INSTRUCTION VIDEO STUCK');
+            }
           }
         } else {
           _stuckFrameCount = 0;
@@ -405,6 +415,8 @@ class _IntroScreenState extends State<IntroScreen> {
       debugPrint('🎬 INITIALIZING VIDEO 2 (INSTRUCTION)');
       debugPrint('═══════════════════════════════════════════════════════');
 
+      _instructionVideoController?.removeListener(_checkInstructionProgress);
+      _instructionVideoController?.dispose();
       _instructionVideoController = VideoPlayerController.asset(
         'assets/video/instruction_vid.mp4',
       );
@@ -420,15 +432,14 @@ class _IntroScreenState extends State<IntroScreen> {
     } catch (e, stack) {
       debugPrint('❌ ERROR LOADING INSTRUCTION VIDEO: $e');
       debugPrint('Stack: $stack');
-      // Skip to main app
-      _startFadeAndNavigate();
+      await _retryInstructionInitialization();
     }
   }
 
   // Start playing instruction video
   Future<void> _startInstructionVideo() async {
     if (_instructionVideoController == null) {
-      _startFadeAndNavigate();
+      await _retryInstructionInitialization();
       return;
     }
 
@@ -436,6 +447,7 @@ class _IntroScreenState extends State<IntroScreen> {
     _instructionVideoController!.addListener(_checkInstructionProgress);
 
     await _instructionVideoController!.play();
+    _instructionPlaybackStarted = true;
     debugPrint('▶️ Instruction video playing...');
 
     await _ensurePlaybackStarted(_instructionVideoController!, 'instruction');
@@ -460,9 +472,9 @@ class _IntroScreenState extends State<IntroScreen> {
 
     _instructionTimeoutTimer?.cancel();
     _instructionTimeoutTimer = Timer(timeoutDuration, () {
-      if (!_instructionCompleted && mounted) {
+      if (!_instructionCompleted && mounted && _instructionPlaybackStarted) {
         debugPrint('⚠️ INSTRUCTION VIDEO TIMEOUT - forcing navigation');
-        _startFadeAndNavigate();
+        _markInstructionComplete('INSTRUCTION VIDEO TIMEOUT');
       }
     });
   }
@@ -478,8 +490,7 @@ class _IntroScreenState extends State<IntroScreen> {
     // Check for completion
     if (duration.inMilliseconds > 0 &&
         position.inMilliseconds >= duration.inMilliseconds - 100) {
-      debugPrint('✅ INSTRUCTION VIDEO COMPLETE');
-      _startFadeAndNavigate();
+      _markInstructionComplete('INSTRUCTION VIDEO COMPLETE');
       return;
     }
 
@@ -487,16 +498,52 @@ class _IntroScreenState extends State<IntroScreen> {
     if (!value.isPlaying &&
         duration.inMilliseconds > 0 &&
         position.inMilliseconds > duration.inMilliseconds - 500) {
-      debugPrint('✅ INSTRUCTION VIDEO STOPPED NEAR END - treating as complete');
-      _startFadeAndNavigate();
+      _markInstructionComplete('INSTRUCTION VIDEO STOPPED NEAR END');
     }
+  }
+
+  void _markInstructionComplete(String reason) {
+    if (_instructionCompleted) return;
+    debugPrint('✅ $reason');
+    _instructionCompleted = true;
+    _startFadeAndNavigate();
+  }
+
+  Future<void> _retryIntroInitialization() async {
+    if (_introInitRetryCount >= _maxInitRetries || !mounted) {
+      debugPrint('⚠️ Intro video failed after retries - switching to instruction');
+      _switchToInstructionVideo();
+      return;
+    }
+
+    _introInitRetryCount++;
+    debugPrint('↻ Retrying intro initialization ($_introInitRetryCount)');
+    await Future.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
+    await _initializeIntroVideo();
+  }
+
+  Future<void> _retryInstructionInitialization() async {
+    if (_instructionInitRetryCount >= _maxInitRetries || !mounted) {
+      debugPrint(
+          '⚠️ Instruction video failed after retries - proceeding to splash');
+      _instructionCompleted = true;
+      _startFadeAndNavigate();
+      return;
+    }
+
+    _instructionInitRetryCount++;
+    debugPrint(
+        '↻ Retrying instruction initialization ($_instructionInitRetryCount)');
+    await Future.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
+    await _initializeInstructionVideo();
   }
 
   // Start fade to white and navigate to main app
   Future<void> _startFadeAndNavigate() async {
-    if (_hasNavigated) return;
+    if (_hasNavigated || !_instructionCompleted) return;
     _hasNavigated = true;
-    _instructionCompleted = true;
 
     debugPrint('═══════════════════════════════════════════════════════');
     debugPrint('🌟 STARTING FADE TRANSITION (800ms white, 4000ms navigate)');

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -70,6 +70,8 @@ class _IntroScreenState extends State<IntroScreen> {
   int _introInitRetryCount = 0;
   int _instructionInitRetryCount = 0;
   static const int _maxInitRetries = 2;
+  bool _isIntroInitializing = false;
+  bool _isInstructionInitializing = false;
 
   @override
   void initState() {
@@ -87,6 +89,8 @@ class _IntroScreenState extends State<IntroScreen> {
 
   // Initialize intro video (Video 1) with surface-ready detection
   Future<void> _initializeIntroVideo() async {
+    if (_isIntroInitializing) return;
+    _isIntroInitializing = true;
     try {
       _introVideoController?.removeListener(_checkIntroProgress);
       _introVideoController?.dispose();
@@ -143,6 +147,8 @@ class _IntroScreenState extends State<IntroScreen> {
       debugPrint('Stack: $stack');
       // Try MOV format as fallback
       _tryFallbackIntroFormat();
+    } finally {
+      _isIntroInitializing = false;
     }
   }
 
@@ -410,6 +416,8 @@ class _IntroScreenState extends State<IntroScreen> {
 
   // Initialize instruction video if not pre-loaded
   Future<void> _initializeInstructionVideo() async {
+    if (_isInstructionInitializing) return;
+    _isInstructionInitializing = true;
     try {
       debugPrint('═══════════════════════════════════════════════════════');
       debugPrint('🎬 INITIALIZING VIDEO 2 (INSTRUCTION)');
@@ -433,6 +441,8 @@ class _IntroScreenState extends State<IntroScreen> {
       debugPrint('❌ ERROR LOADING INSTRUCTION VIDEO: $e');
       debugPrint('Stack: $stack');
       await _retryInstructionInitialization();
+    } finally {
+      _isInstructionInitializing = false;
     }
   }
 
@@ -510,32 +520,44 @@ class _IntroScreenState extends State<IntroScreen> {
   }
 
   Future<void> _retryIntroInitialization() async {
-    if (_introInitRetryCount >= _maxInitRetries || !mounted) {
-      debugPrint('⚠️ Intro video failed after retries - switching to instruction');
-      _switchToInstructionVideo();
+    if (!mounted) {
       return;
     }
 
-    _introInitRetryCount++;
+    if (_introInitRetryCount >= _maxInitRetries) {
+      debugPrint(
+          '⚠️ Intro video failed after retries - continuing to retry...');
+      _introInitRetryCount = 0;
+    } else {
+      _introInitRetryCount++;
+    }
+
+    final delay =
+        Duration(milliseconds: 750 + (_introInitRetryCount * 250));
     debugPrint('↻ Retrying intro initialization ($_introInitRetryCount)');
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future.delayed(delay);
     if (!mounted) return;
     await _initializeIntroVideo();
   }
 
   Future<void> _retryInstructionInitialization() async {
-    if (_instructionInitRetryCount >= _maxInitRetries || !mounted) {
-      debugPrint(
-          '⚠️ Instruction video failed after retries - proceeding to splash');
-      _instructionCompleted = true;
-      _startFadeAndNavigate();
+    if (!mounted) {
       return;
     }
 
-    _instructionInitRetryCount++;
+    if (_instructionInitRetryCount >= _maxInitRetries) {
+      debugPrint(
+          '⚠️ Instruction video failed after retries - continuing to retry...');
+      _instructionInitRetryCount = 0;
+    } else {
+      _instructionInitRetryCount++;
+    }
+
+    final delay =
+        Duration(milliseconds: 750 + (_instructionInitRetryCount * 250));
     debugPrint(
         '↻ Retrying instruction initialization ($_instructionInitRetryCount)');
-    await Future.delayed(const Duration(milliseconds: 500));
+    await Future.delayed(delay);
     if (!mounted) return;
     await _initializeInstructionVideo();
   }

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -76,7 +76,7 @@ class _IntroScreenState extends State<IntroScreen> {
   static const int _maxInitRetries = 2;
   bool _isIntroInitializing = false;
   bool _isInstructionInitializing = false;
-  static const Duration _videoInitTimeout = Duration(seconds: 30);
+  static const Duration _videoInitTimeout = Duration(seconds: 6);
 
   @override
   void initState() {
@@ -116,14 +116,33 @@ class _IntroScreenState extends State<IntroScreen> {
 
   void _startWindowsFallbackTimer() {
     _windowsFallbackTimer?.cancel();
-    _windowsFallbackTimer = Timer(const Duration(seconds: 4), () {
-      if (!mounted || _hasNavigated) return;
-      if (!_introPlaybackStarted && !_instructionPlaybackStarted) {
-        debugPrint('WINDOWS SAFE MODE ACTIVE');
-        debugPrint(
-            '⚠️ WINDOWS FALLBACK - videos did not start, enabling safe mode');
-        _startWindowsKillSwitch();
+    final startedAt = DateTime.now();
+    _windowsFallbackTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      if (!mounted || _hasNavigated) {
+        timer.cancel();
+        return;
       }
+      if (_introPlaybackStarted || _instructionPlaybackStarted) {
+        timer.cancel();
+        return;
+      }
+
+      final elapsed = DateTime.now().difference(startedAt);
+      if (elapsed < const Duration(seconds: 6)) {
+        return;
+      }
+
+      if (_isIntroInitializing || _isInstructionInitializing) {
+        debugPrint(
+            '⏳ WINDOWS FALLBACK WAIT - intro still initializing (${elapsed.inSeconds}s)');
+        return;
+      }
+
+      debugPrint('WINDOWS SAFE MODE ACTIVE');
+      debugPrint(
+          '⚠️ WINDOWS FALLBACK - videos did not start, enabling safe mode');
+      timer.cancel();
+      _startWindowsKillSwitch();
     });
   }
 

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -22,7 +22,9 @@
 // - Smooth fade transitions
 
 import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:video_player/video_player.dart';
 import 'package:theta_audio_mvp/app/router.dart';
 
@@ -73,6 +75,8 @@ class _IntroScreenState extends State<IntroScreen> {
   bool _isIntroInitializing = false;
   bool _isInstructionInitializing = false;
   static const Duration _videoInitTimeout = Duration(seconds: 30);
+  File? _introTempFile;
+  File? _instructionTempFile;
 
   @override
   void initState() {
@@ -147,10 +151,43 @@ class _IntroScreenState extends State<IntroScreen> {
     } catch (e, stack) {
       debugPrint('❌ ERROR LOADING INTRO VIDEO: $e');
       debugPrint('Stack: $stack');
-      // Try MOV format as fallback
-      _tryFallbackIntroFormat();
+      await _tryFileIntroFallback('assets/video/intro_video.mp4');
     } finally {
       _isIntroInitializing = false;
+    }
+  }
+
+  Future<void> _tryFileIntroFallback(String assetPath) async {
+    try {
+      debugPrint('🔄 Trying intro fallback via file load');
+      _introVideoController?.removeListener(_checkIntroProgress);
+      _introVideoController?.dispose();
+      _introPlaybackStarted = false;
+      _introTempFile = await _loadAssetToFile(assetPath, 'intro_video.mp4');
+      _introVideoController = VideoPlayerController.file(_introTempFile!);
+
+      await _initializeController(_introVideoController!, 'intro file');
+      await _introVideoController!.setVolume(1.0);
+
+      setState(() {
+        _isIntroInitialized = true;
+      });
+
+      _introVideoController!.addListener(_checkIntroProgress);
+      await _introVideoController!.play();
+      _introPlaybackStarted = true;
+
+      await _ensurePlaybackStarted(_introVideoController!, 'intro');
+      await _waitForFirstFrame(_introVideoController!, 'intro');
+      if (_allowPlaybackFallbacks) {
+        _startIntroTimeout();
+        _startPlaybackMonitor();
+      }
+      _preloadInstructionVideo();
+    } catch (fallbackError, fallbackStack) {
+      debugPrint('❌ File fallback failed: $fallbackError');
+      debugPrint('Stack: $fallbackStack');
+      _tryFallbackIntroFormat();
     }
   }
 
@@ -447,9 +484,39 @@ class _IntroScreenState extends State<IntroScreen> {
     } catch (e, stack) {
       debugPrint('❌ ERROR LOADING INSTRUCTION VIDEO: $e');
       debugPrint('Stack: $stack');
-      await _retryInstructionInitialization();
+      await _tryInstructionFileFallback('assets/video/instruction_vid.mp4');
     } finally {
       _isInstructionInitializing = false;
+    }
+  }
+
+  Future<void> _tryInstructionFileFallback(String assetPath) async {
+    try {
+      debugPrint('🔄 Trying instruction fallback via file load');
+      _instructionVideoController?.removeListener(_checkInstructionProgress);
+      _instructionVideoController?.dispose();
+      _instructionPlaybackStarted = false;
+      _instructionTempFile =
+          await _loadAssetToFile(assetPath, 'instruction_vid.mp4');
+      _instructionVideoController = VideoPlayerController.file(
+        _instructionTempFile!,
+      );
+
+      await _initializeController(
+        _instructionVideoController!,
+        'instruction file',
+      );
+      await _instructionVideoController!.setVolume(1.0);
+
+      setState(() {
+        _isInstructionInitialized = true;
+      });
+
+      _startInstructionVideo();
+    } catch (fallbackError, fallbackStack) {
+      debugPrint('❌ Instruction file fallback failed: $fallbackError');
+      debugPrint('Stack: $fallbackStack');
+      await _retryInstructionInitialization();
     }
   }
 
@@ -533,6 +600,16 @@ class _IntroScreenState extends State<IntroScreen> {
     } on TimeoutException {
       throw TimeoutException('Video init timed out: $label');
     }
+  }
+
+  Future<File> _loadAssetToFile(String assetPath, String fileName) async {
+    final data = await rootBundle.load(assetPath);
+    final bytes = data.buffer.asUint8List();
+    final directory = Directory.systemTemp;
+    final filePath = '${directory.path}${Platform.pathSeparator}$fileName';
+    final file = File(filePath);
+    await file.writeAsBytes(bytes, flush: true);
+    return file;
   }
 
   Future<void> _retryIntroInitialization() async {
@@ -633,6 +710,8 @@ class _IntroScreenState extends State<IntroScreen> {
     // Dispose controllers
     _introVideoController?.dispose();
     _instructionVideoController?.dispose();
+    _deleteTempFile(_introTempFile);
+    _deleteTempFile(_instructionTempFile);
 
     debugPrint('✅ Intro screen disposed');
     super.dispose();
@@ -724,5 +803,16 @@ class _IntroScreenState extends State<IntroScreen> {
         ),
       ),
     );
+  }
+
+  void _deleteTempFile(File? file) {
+    if (file == null) return;
+    try {
+      if (file.existsSync()) {
+        file.deleteSync();
+      }
+    } catch (_) {
+      // Ignore cleanup errors.
+    }
   }
 }

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -88,12 +88,7 @@ class _IntroScreenState extends State<IntroScreen> {
           const AssetImage('assets/images/latest_pc.png'),
           context,
         );
-        if (Platform.isWindows) {
-          debugPrint('WINDOWS SAFE MODE ACTIVE');
-          _startWindowsKillSwitch();
-        } else {
-          _initializeIntroVideo();
-        }
+        _initializeIntroVideo();
         if (Platform.isWindows) {
           _startWindowsFallbackTimer();
         }
@@ -121,12 +116,13 @@ class _IntroScreenState extends State<IntroScreen> {
 
   void _startWindowsFallbackTimer() {
     _windowsFallbackTimer?.cancel();
-    _windowsFallbackTimer = Timer(const Duration(seconds: 5), () {
+    _windowsFallbackTimer = Timer(const Duration(seconds: 4), () {
       if (!mounted || _hasNavigated) return;
       if (!_introPlaybackStarted && !_instructionPlaybackStarted) {
+        debugPrint('WINDOWS SAFE MODE ACTIVE');
         debugPrint(
-            '⚠️ WINDOWS FALLBACK - videos did not start, navigating to home');
-        _startFadeAndNavigate();
+            '⚠️ WINDOWS FALLBACK - videos did not start, enabling safe mode');
+        _startWindowsKillSwitch();
       }
     });
   }

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -713,7 +713,7 @@ class _IntroScreenState extends State<IntroScreen> {
                     child: SizedBox.expand(
                       child: Image.asset(
                         'assets/images/latest_pc.png',
-                        fit: BoxFit.contain,
+                        fit: Platform.isWindows ? BoxFit.cover : BoxFit.contain,
                       ),
                     ),
                   ),

--- a/lib/intro_screen.dart
+++ b/lib/intro_screen.dart
@@ -55,6 +55,7 @@ class _IntroScreenState extends State<IntroScreen> {
   Timer? _instructionTimeoutTimer;
   Timer? _playbackMonitorTimer;
   Timer? _windowsFallbackTimer;
+  Timer? _windowsKillSwitchTimer;
 
   // Track last position for stuck detection
   Duration _lastIntroPosition = Duration.zero;
@@ -67,6 +68,7 @@ class _IntroScreenState extends State<IntroScreen> {
   bool _showLatestPc = false;
   double _latestPcOpacity = 0.0;
   final bool _allowPlaybackFallbacks = true;
+  bool _showWindowsSafeMode = false;
   bool _introPlaybackStarted = false;
   bool _instructionPlaybackStarted = false;
   int _introInitRetryCount = 0;
@@ -79,17 +81,41 @@ class _IntroScreenState extends State<IntroScreen> {
   @override
   void initState() {
     super.initState();
+    debugPrint('🧭 IntroScreen initState');
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
         precacheImage(
           const AssetImage('assets/images/latest_pc.png'),
           context,
         );
-        _initializeIntroVideo();
+        if (Platform.isWindows) {
+          debugPrint('WINDOWS SAFE MODE ACTIVE');
+          _startWindowsKillSwitch();
+        } else {
+          _initializeIntroVideo();
+        }
         if (Platform.isWindows) {
           _startWindowsFallbackTimer();
         }
       }
+    });
+  }
+
+  void _startWindowsKillSwitch() {
+    setState(() {
+      _showWindowsSafeMode = true;
+    });
+    Timer(const Duration(seconds: 1), () {
+      if (!mounted) return;
+      setState(() {
+        _showWindowsSafeMode = false;
+      });
+    });
+    _windowsKillSwitchTimer?.cancel();
+    _windowsKillSwitchTimer = Timer(const Duration(seconds: 2), () {
+      if (!mounted || _hasNavigated) return;
+      debugPrint('NAVIGATING TO HOME');
+      _startFadeAndNavigate();
     });
   }
 
@@ -145,6 +171,7 @@ class _IntroScreenState extends State<IntroScreen> {
       await _introVideoController!.play();
       _introPlaybackStarted = true;
       _windowsFallbackTimer?.cancel();
+      _windowsKillSwitchTimer?.cancel();
       debugPrint('▶️ Intro video play() called...');
 
       await _ensurePlaybackStarted(_introVideoController!, 'intro');
@@ -472,6 +499,7 @@ class _IntroScreenState extends State<IntroScreen> {
     await _instructionVideoController!.play();
     _instructionPlaybackStarted = true;
     _windowsFallbackTimer?.cancel();
+    _windowsKillSwitchTimer?.cancel();
     debugPrint('▶️ Instruction video playing...');
 
     await _ensurePlaybackStarted(_instructionVideoController!, 'instruction');
@@ -599,6 +627,8 @@ class _IntroScreenState extends State<IntroScreen> {
     _instructionTimeoutTimer?.cancel();
     _playbackMonitorTimer?.cancel();
     _windowsFallbackTimer?.cancel();
+    _windowsKillSwitchTimer?.cancel();
+    _windowsKillSwitchTimer?.cancel();
 
     // Stop any playing video
     _introVideoController?.pause();
@@ -634,6 +664,7 @@ class _IntroScreenState extends State<IntroScreen> {
     _instructionTimeoutTimer?.cancel();
     _playbackMonitorTimer?.cancel();
     _windowsFallbackTimer?.cancel();
+    _windowsKillSwitchTimer?.cancel();
 
     // Remove listeners
     _introVideoController?.removeListener(_checkIntroProgress);
@@ -690,6 +721,31 @@ class _IntroScreenState extends State<IntroScreen> {
               ),
             ),
           if (!_isIntroInitialized && !_hasNavigated) _buildLoadingIndicator(),
+          if (_showWindowsSafeMode)
+            Positioned.fill(
+              child: Align(
+                alignment: Alignment.topCenter,
+                child: Padding(
+                  padding: const EdgeInsets.only(top: 48),
+                  child: Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.black.withValues(alpha: 0.7),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: const Text(
+                      'Windows Safe Mode: Skipping Intro',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
         ],
       ),
     );


### PR DESCRIPTION
### **User description**
### Motivation
- Reduce duplicated polling logic by centralizing periodic session/status refresh in the home page so the Divine Shuffle popup no longer starts its own timer.
- Prevent lifecycle-related crashes and stale updates by adding mounted guards around session transitions and avoiding background timers after disposal.

### Description
- Moved periodic refresh invocation into `lib/features/home/pages/theta_home_page.dart` by adding `_handlePeriodicRefresh()` and calling it from the existing `Timer.periodic` as well as once immediately at startup.
- Removed the internal `_sessionCheckTimer` and its periodic creation from `lib/divine_shuffle_popup.dart` and added a public `refreshSessionIfNeeded()` method so the home page can drive session checks.
- Hardened lifecycle behavior by adding `mounted` checks in `_checkSessionChange()` and `_handleSessionChange()` and ensured session updates only run when the popup is in Phase 2 (not during intro).
- Updated the home page to call the popup's `refreshSessionIfNeeded()` so session-type transitions are consolidated and coordinated from one timer.

### Testing
- Attempted `flutter analyze`, but the `flutter` command is not available in the environment so static analysis could not be run (tooling unavailable).
- Verified repository changes locally via `git status` and committed the modifications, and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6978cd7ed230832a9776afe84c40b1b3)


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidate periodic refresh logic from Divine Shuffle popup to home page

- Remove internal session check timer from popup, add public `refreshSessionIfNeeded()` method

- Add `mounted` guards to prevent lifecycle-related crashes and stale updates

- Call popup refresh from home page's centralized timer for coordinated session transitions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Home Page Timer<br/>1 minute interval"] --> B["_handlePeriodicRefresh()"]
  B --> C["Update UI status"]
  B --> D["Call popup<br/>refreshSessionIfNeeded()"]
  D --> E["Check session change<br/>with mounted guard"]
  F["Removed popup<br/>internal timer"] -.-> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>divine_shuffle_popup.dart</strong><dd><code>Remove internal timer, add external refresh method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/divine_shuffle_popup.dart

<ul><li>Removed <code>_sessionCheckTimer</code> field and its periodic creation in <br><code>_transitionToPhase2()</code><br> <li> Added public <code>refreshSessionIfNeeded()</code> method to allow external refresh <br>invocation<br> <li> Added <code>mounted</code> checks in <code>_checkSessionChange()</code> and <br><code>_handleSessionChange()</code> to prevent crashes after disposal<br> <li> Added guard to only refresh when in Phase 2 (not during intro phase)</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/59/files#diff-d38d6a44541706a688ee5626e869ecba86d29c291eee5e023122dd1e0b0e34b4">+10/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>theta_home_page.dart</strong><dd><code>Centralize periodic refresh with popup coordination</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/features/home/pages/theta_home_page.dart

<ul><li>Extracted periodic refresh logic into new <code>_handlePeriodicRefresh()</code> <br>method<br> <li> Call <code>_handlePeriodicRefresh()</code> from existing timer and immediately at <br>startup<br> <li> Invoke popup's <code>refreshSessionIfNeeded()</code> from the centralized home page <br>timer<br> <li> Add <code>mounted</code> check to prevent updates after widget disposal</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/59/files#diff-4690322a3dc4ff9710bb44f8489a0866fc0afe1af4efa4e633128a55ce234009">+12/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

