### PR TITLE
Defer DivineShuffle refresh listener until after intro to prevent intro skip

### DIFF
--- a/lib/divine_shuffle_popup.dart
+++ b/lib/divine_shuffle_popup.dart
@@ -94,6 +94,7 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   final ScrollController _prayerCardScrollController = ScrollController();
   Timer? _prayerCardAutoScrollTimer;
   late final VoidCallback _refreshListener;
+  bool _isRefreshListenerActive = false;
 
   // ═══════════════════════════════════════════════════════════════════════════
   // COLORS - Option 5 "Soft & Spiritual" Theme (EXACT MATCH)
@@ -122,7 +123,6 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
       if (!mounted || _currentIntroPart != 0) return;
       _checkSessionChange();
     };
-    refreshNotifier.addListener(_refreshListener);
 
     if (widget.isVisible) {
       _startIntroSequence();
@@ -161,7 +161,9 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
     _part3ScrollController.dispose();
     _prayerCardScrollController.dispose();
     _ttsPlayer?.dispose();
-    refreshNotifier.removeListener(_refreshListener);
+    if (_isRefreshListenerActive) {
+      refreshNotifier.removeListener(_refreshListener);
+    }
     super.dispose();
   }
 
@@ -334,6 +336,11 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
       _contentOpacity = 1.0;
     });
 
+    if (!_isRefreshListenerActive) {
+      refreshNotifier.addListener(_refreshListener);
+      _isRefreshListenerActive = true;
+    }
+
     widget.onPhase1Complete?.call();
   }
 
@@ -342,6 +349,7 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   // ═══════════════════════════════════════════════════════════════════════════
 
   void _checkSessionChange() {
+    if (_currentIntroPart != 0) return;
     if (!mounted || widget.isGoliathMode) {
       return; // Don't check time when in Goliath mode or after disposal
     }
@@ -355,6 +363,7 @@ class DivineShufflePopupState extends State<DivineShufflePopup>
   }
 
   Future<void> _handleSessionChange(String newSession) async {
+    if (_currentIntroPart != 0) return;
     if (!mounted) return;
     // Fade out top panel
     setState(() => _topPanelOpacity = 0.0);

--- a/lib/features/home/pages/theta_home_page.dart
+++ b/lib/features/home/pages/theta_home_page.dart
@@ -65,6 +65,7 @@ class _ThetaHomePageState extends State<ThetaHomePage>
   @override
   bool _showDivineShuffle = false;
   bool _introComplete = false;
+  bool _introDelayElapsed = false;
   @override
   String? _currentPrayerPath;
   String? _currentPrayerNumber;
@@ -163,6 +164,7 @@ class _ThetaHomePageState extends State<ThetaHomePage>
           debugPrint('🔀 7-second delay complete - showing Divine Shuffle');
           setState(() {
             _showDivineShuffle = true;
+            _introDelayElapsed = true;
           });
           // Start background fade AFTER Divine Shuffle appears
           _startBackgroundFade();
@@ -180,6 +182,7 @@ class _ThetaHomePageState extends State<ThetaHomePage>
 
   void _handlePeriodicRefresh() {
     if (!mounted) return;
+    if (!_introComplete && !_introDelayElapsed) return;
     refreshNotifier.value++;
   }
 


### PR DESCRIPTION
### **User description**
### Motivation
- The global `refreshNotifier` was triggering during the Divine Shuffle intro, causing the popup to skip the intro videos and jump to Phase 2 when the home page fired an immediate refresh at startup. 
- The intent is to preserve the startup flow: Wallpaper Fade → Intro Parts 1–3 → Transition to Phase 2 → Activate refresh listener → Theta Logo/Phase 2.

### Description
- In `lib/divine_shuffle_popup.dart` stop adding the `refreshNotifier` listener in `initState()` and instead track listener activation with a new `bool _isRefreshListenerActive` flag. 
- Add the listener only once the intro completes by calling `refreshNotifier.addListener(_refreshListener)` from `_transitionToPhase2()` and mark `_isRefreshListenerActive = true` so teardown is safe. 
- Guard listener removal in `dispose()` with `if (_isRefreshListenerActive) refreshNotifier.removeListener(_refreshListener);` to avoid removing a listener that was never added. 
- Harden session-change logic by ensuring `void _checkSessionChange()` and `Future<void> _handleSessionChange(String)` return early if the intro is still active (`if (_currentIntroPart != 0) return;`).
- In `lib/features/home/pages/theta_home_page.dart` add a `_introDelayElapsed` flag that is set after the configured 7-second startup delay and change `_handlePeriodicRefresh()` to only increment `refreshNotifier.value` if `_introComplete` is true or `_introDelayElapsed` has elapsed, preventing immediate refreshes during the intro.

### Testing
- Ran `flutter analyze` in this environment, which failed due to `flutter` not being installed here (static analysis could not be executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69824f6702a08328bca383ae288e45eb)


___

### **PR Type**
Bug fix


___

### **Description**
- Defer refresh listener activation until intro completes

- Prevent immediate refresh notifications during startup sequence

- Add early returns in session-change logic during intro

- Guard listener removal to avoid double-removal errors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Startup begins"] --> B["Wallpaper fade"]
  B --> C["Intro sequence starts"]
  C --> D["7-second delay elapses"]
  D --> E["_introDelayElapsed = true"]
  E --> F["Intro completes"]
  F --> G["_transitionToPhase2 activates listener"]
  G --> H["Refresh notifications enabled"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>divine_shuffle_popup.dart</strong><dd><code>Defer refresh listener until intro completion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/divine_shuffle_popup.dart

<ul><li>Added <code>_isRefreshListenerActive</code> flag to track listener state<br> <li> Removed listener registration from <code>initState()</code> to defer activation<br> <li> Activated listener in <code>_transitionToPhase2()</code> after intro completes<br> <li> Guarded listener removal in <code>dispose()</code> with flag check<br> <li> Added early return guards in <code>_checkSessionChange()</code> and <br><code>_handleSessionChange()</code> to prevent session changes during intro</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/60/files#diff-d38d6a44541706a688ee5626e869ecba86d29c291eee5e023122dd1e0b0e34b4">+11/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>theta_home_page.dart</strong><dd><code>Prevent refresh during intro startup sequence</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

lib/features/home/pages/theta_home_page.dart

<ul><li>Added <code>_introDelayElapsed</code> flag to track 7-second startup delay <br>completion<br> <li> Set flag to true when Divine Shuffle appears after 7-second delay<br> <li> Modified <code>_handlePeriodicRefresh()</code> to skip refresh until intro <br>completes or delay elapses</ul>


</details>


  </td>
  <td><a href="https://github.com/fearless-labs1/theta-audio-mvp/pull/60/files#diff-4690322a3dc4ff9710bb44f8489a0866fc0afe1af4efa4e633128a55ce234009">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

